### PR TITLE
Prepare for the last build that uses the old docs infrastructure

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -37,7 +37,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: typst/typst
-          ref: ${{ env.INPUT_REF }}
+          # Temporary workaround for using the old docs infrastructure
+          ref: main
+          fetch-depth: 20
+      - run: git switch --detach ${{ env.INPUT_REF }}
 
       - uses: actions/checkout@v6
         with:

--- a/scripts/get_revision.py
+++ b/scripts/get_revision.py
@@ -25,7 +25,7 @@ def get_description() -> str:
     # As a result, `git describe --tags` is always relative to v0.11.0, like `v0.11.0-1051-g586b04948`.
 
     name_full = run(
-        ["git", "name-rev", "--name-only", "HEAD"],
+        ["git", "name-rev", "--name-only", "--no-undefined", "HEAD"],
         capture_output=True,
         text=True,
         check=True,


### PR DESCRIPTION
https://github.com/typst-community/dev-builds/actions/runs/25411057214 on `main` generated `docs-undefined.2026-05-05.0d72726`.
This PR makes it `docs-main.2026-05-05.0d72726`.

See https://github.com/typst-community/typst-docs-web/discussions/38#discussioncomment-16822258 and https://github.com/typst/typst/pull/8138 for background.

## Test run

```sh
gh workflow run --repo YDX-2147483647/typst-dev-builds --ref pr-8138 docs.yaml --raw-field ref=0d727267164629c6124bd2af1f334c1c7edc9f98
```

https://github.com/YDX-2147483647/typst-dev-builds/actions/runs/25411933793

I've confirmed that the artifacts in the test run work with https://github.com/typst-community/typst-docs-web/tree/59cabb4.