### PR TITLE
build(deps): bump dtolnay/rust-toolchain to 1.96.0, the latest version at present

### DIFF
--- a/.github/workflows/typst.yaml
+++ b/.github/workflows/typst.yaml
@@ -64,7 +64,7 @@ jobs:
           echo "revision=$revision" >> "$GITHUB_OUTPUT"
           echo "Revision: \`$revision\`." >> "$GITHUB_STEP_SUMMARY"
 
-      - uses: dtolnay/rust-toolchain@1.100.0
+      - uses: dtolnay/rust-toolchain@1.96.0
         with:
           target: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Reverts typst-community/dev-builds#20

rustc 1.100.0 doesn't exist yet!